### PR TITLE
Fixed Check bug

### DIFF
--- a/Bishop.cpp
+++ b/Bishop.cpp
@@ -15,7 +15,7 @@ bool Bishop::checkMove(const Position& pos) const
 	int colMove, rowMove;
 	if (std::abs(_index.getLetter() - pos.getLetter()) == std::abs(_index.getNumber() - pos.getNumber()))
 	{
-		// If the bishop moves left and down
+		// Checking which direction the bishop moves to
 		if (_index.getLetter() > pos.getLetter())
 			colMove = -1;
 		else
@@ -35,3 +35,4 @@ bool Bishop::checkMove(const Position& pos) const
 	}
 	return false;
 }
+

--- a/Bishop.h
+++ b/Bishop.h
@@ -2,7 +2,7 @@
 #include "Piece.h"
 #include "Board.h"
 #include <cmath>
-class Bishop : public Piece
+class Bishop: public Piece
 {
 public:
 	Bishop(Position pos, char type, Board* board);
@@ -10,3 +10,4 @@ public:
 	bool checkMove(const Position& pos) const;
 
 };
+

--- a/Board.cpp
+++ b/Board.cpp
@@ -15,7 +15,6 @@ Board::~Board()
 			delete _pieces[i][j];
 		}
 	}
-
 	delete _black;
 	delete _white;
 }

--- a/Board.h
+++ b/Board.h
@@ -3,8 +3,8 @@
 #include "Rook.h"
 #include "King.h"
 #include "Bishop.h"
-#include "Pawn.h"
 #include "Knight.h"
+#include "Pawn.h"
 #include "Queen.h"
 
 #include <string>

--- a/Knight.cpp
+++ b/Knight.cpp
@@ -2,17 +2,18 @@
 
 Knight::Knight(Position pos, char type, Board* board) : Piece(pos, type, board)
 {
-}
+} 
+
 
 Knight::~Knight()
 {
 }
 
 bool Knight::checkMove(const Position& pos) const
-{
+ {
 	int numDiff = _index.getNumber() - pos.getNumber();
 	int letDiff = _index.getLetter() - pos.getLetter();
-
-	return (abs(numDiff) == 2 && abs(letDiff) == 1)
-		|| (abs(numDiff) == 1 && abs(letDiff) == 2);
+	
+		return (abs(numDiff) == 2 && abs(letDiff) == 1)
+				|| (abs(numDiff) == 1 && abs(letDiff) == 2);
 }

--- a/Knight.h
+++ b/Knight.h
@@ -2,11 +2,12 @@
 #include "Piece.h"
 #include "Board.h"
 
-class Knight : public Piece
+class Knight: public Piece
 {
 public:
 	Knight(Position pos, char type, Board* board);
 	~Knight();
 	bool checkMove(const Position& pos) const;
+
 };
 

--- a/Pawn.cpp
+++ b/Pawn.cpp
@@ -1,8 +1,11 @@
 #include "Pawn.h"
 
+
+
 Pawn::Pawn(Position pos, char type, Board* board) : Piece(pos, type, board)
 {
 }
+
 
 Pawn::~Pawn()
 {
@@ -48,7 +51,8 @@ bool Pawn::checkMove(const Position& pos) const
 	return isValidMove;
 }
 
-bool Pawn::isAtStartPosition() const{
-	return (isWhite() && _index.getNumber() == 2) 
-		|| (!isWhite() && _index.getNumber() == 7);
+bool Pawn::isAtStartPosition() const 
+{
+	return (isWhite() && _index.getNumber() == 2)
+		 || (!isWhite() && _index.getNumber() == 7);
 }

--- a/Position.cpp
+++ b/Position.cpp
@@ -42,20 +42,8 @@ int Position::getNumber() const
 {
 	return _number;
 }
+
 int Position::getIntLetter() const
 {
 	return _letter - 'a';
 }
-
-/* A   B   C   D   E   F   G   H
-8  0   1   2   3   4   5   6   7
-7  8   9   10  11  12  13  14  15
-6  16  17 
-5
-4
-3
-2
-1
-
-
-*/

--- a/Queen.cpp
+++ b/Queen.cpp
@@ -10,81 +10,8 @@ Queen::~Queen()
 
 bool Queen::checkMove(const Position& pos) const
 {
-	int numDiff = _index.getNumber() - pos.getNumber();
-	int letDiff = _index.getLetter() - pos.getLetter();
-	
-	//check if the move is legal in any direction
-	bool isDiagonalMove = abs(numDiff) == abs(letDiff)
-		&& numDiff != 0 && letDiff != 0;
-
-	bool isVerticalMove = abs(numDiff) > 0 && abs(letDiff) == 0;
-	bool isHorizontalMove = abs(numDiff) == 0 && abs(letDiff) > 0;
-
-	
-	if (!isVerticalMove && !isHorizontalMove && !isDiagonalMove)
-		return false;
-
-	//determine the exact direction of the movement
-	int numSign = 0;
-	int letSign = 0;
-
-	if (isVerticalMove) 
-		numSign = numDiff < 0 ? 1 : -1;
-
-	if (isHorizontalMove) 
-		letSign = letDiff < 0 ? 1 : -1;
-
-	if (isDiagonalMove)
-	{
-		numSign = numDiff < 0 ? 1 : -1;
-		letSign = letDiff < 0 ? 1 : -1;
-	}
-	
-	//start checking if move is valid
-	int num = _index.getNumber() + numSign;
-	int let = _index.getIntLetter() + letSign;
-	
-	bool wayIsEmpy = true;
-	bool whileCondition = false;
-
-	if (isVerticalMove) {
-		whileCondition = num != pos.getNumber();
-	}
-	else if (isHorizontalMove) {
-		whileCondition = let != pos.getIntLetter();
-	}
-	else if (isDiagonalMove) {
-		whileCondition = num != pos.getNumber()
-			&& let != pos.getIntLetter();
-	}
-
-	//check if there are pieces blocking the movement
-	while (whileCondition) 
-	{
-		Position *tmpPos = new Position(let + 'a', num);
-
-		if ((*_board)[*tmpPos] != nullptr) {
-			wayIsEmpy = false;
-			break;
-		}
-		else {
-			delete tmpPos;
-		}
-
-		num += numSign;
-		let += letSign;
-
-		//calculate if the loop should continue
-		if (isVerticalMove) {
-			whileCondition = num != pos.getNumber();
-		}
-		else if (isHorizontalMove) {
-			whileCondition = let != pos.getIntLetter();
-		}
-		else if (isDiagonalMove) {
-			whileCondition = num != pos.getNumber()
-				&& let != pos.getIntLetter();
-		}
-	}
-	return wayIsEmpy;
+	// A queen can move the same way as both a Rook and a Bishop
+	Bishop b(_index, isWhite() ? 'B' : 'b', _board);
+	Rook r(_index, isWhite() ? 'R' : 'r', _board);
+	return r.checkMove(pos) || b.checkMove(pos);
 }

--- a/Queen.h
+++ b/Queen.h
@@ -7,7 +7,6 @@ class Queen : public Piece
 public:
 	Queen(Position pos, char type, Board* board);
 	~Queen();
-
 	bool checkMove(const Position& pos) const;
 };
 


### PR DESCRIPTION
-Fixed: 
    Check bug, king cannot 'escape' Check by going backwards
-Changed: 
    Queen- checkMove now uses the Bishop and Rook checkMove functions instead.
    GameManager- MakeTurn now first moves the king after checking the move is legal but before checking if it will cause Check on himself. If the move does cause Check, it's reversed back so King does not move.
-Bugs: 
    Weird glitches with black King